### PR TITLE
Week 1 - Training loggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,5 +136,3 @@ dmypy.json
 # Logs and models
 logs/
 models/
-wandb/
-mlruns/

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dmypy.json
 # Logs and models
 logs/
 models/
+wandb/
+mlruns/

--- a/callbacks.py
+++ b/callbacks.py
@@ -1,0 +1,41 @@
+from pytorch_lightning import Callback
+from pytorch_lightning import Trainer
+from pytorch_lightning import LightningModule
+from pytorch_lightning import LightningDataModule
+import pandas as pd
+import wandb
+
+
+class SamplesVisualisationLogger(Callback):
+    """Callback to log wrong predictions from the first batch in the validation set to
+    wandb."""
+
+    def __init__(self, data_module: LightningDataModule) -> None:
+        super().__init__()
+        self.data_module = data_module
+
+    def on_validation_end(self, trainer: Trainer, pl_module: LightningModule) -> None:
+        # Get first batch from validation set
+        batch = next(iter(self.data_module.val_dataloader()))
+        logits, preds = pl_module(batch["input_ids"], batch["attention_mask"])
+        labels = batch["label"]
+        sentences = batch["sentence"]
+        df = pd.DataFrame(
+            {
+                "Sentence": sentences,
+                "Label": labels.numpy(),
+                "Prediction": preds.numpy(),
+            }
+        )
+        # Keep only the portion of the dataframe where predictions are wrong
+        wrong_preds_df = df[df["Label"] != df["Prediction"]]
+        trainer.logger.experiment.log(
+            {
+                "Wrong predictions": wandb.Table(
+                    dataframe=wrong_preds_df,
+                    allow_mixed_types=True,
+                    columns=["Sentence", "Label", "Prediction"],
+                ),
+                "step": trainer.global_step,
+            }
+        )

--- a/data.py
+++ b/data.py
@@ -1,7 +1,10 @@
+from typing import Dict
+
 from torch.utils.data import DataLoader
 import pytorch_lightning as pl
 import datasets
 from transformers import PreTrainedTokenizer
+from transformers.tokenization_utils_base import BatchEncoding
 
 
 class ColaDataModule(pl.LightningDataModule):
@@ -11,7 +14,7 @@ class ColaDataModule(pl.LightningDataModule):
         batch_size: int,
         num_workers: int,
         max_length: int,
-    ):
+    ) -> None:
         """
         Args:
             tokenizer: Pre-trained tokenizer to use to process input text.
@@ -27,11 +30,11 @@ class ColaDataModule(pl.LightningDataModule):
         self.dset = None
         self.data_train, self.data_val, self.data_test, self.data_predict = [None] * 4
 
-    def prepare_data(self):
+    def prepare_data(self) -> None:
         """Download and caches the dataset."""
         self.dset = datasets.load_dataset(path="glue", name="cola")
 
-    def setup(self, stage: str = None):
+    def setup(self, stage: str = None) -> None:
         """
         Tokenizes and formats various data splits.
 
@@ -65,7 +68,7 @@ class ColaDataModule(pl.LightningDataModule):
                 type="torch", columns=["input_ids", "attention_mask", "label"]
             )
 
-    def train_dataloader(self):
+    def train_dataloader(self) -> DataLoader:
         return DataLoader(
             self.data_train,
             batch_size=self.batch_size,
@@ -73,7 +76,7 @@ class ColaDataModule(pl.LightningDataModule):
             shuffle=True,
         )
 
-    def val_dataloader(self):
+    def val_dataloader(self) -> DataLoader:
         return DataLoader(
             self.data_val,
             batch_size=self.batch_size,
@@ -81,7 +84,7 @@ class ColaDataModule(pl.LightningDataModule):
             shuffle=False,
         )
 
-    def test_dataloader(self):
+    def test_dataloader(self) -> DataLoader:
         return DataLoader(
             self.data_test,
             batch_size=self.batch_size,
@@ -89,7 +92,7 @@ class ColaDataModule(pl.LightningDataModule):
             shuffle=False,
         )
 
-    def predict_dataloader(self):
+    def predict_dataloader(self) -> DataLoader:
         return DataLoader(
             self.data_predict,
             batch_size=self.batch_size,
@@ -97,7 +100,7 @@ class ColaDataModule(pl.LightningDataModule):
             shuffle=False,
         )
 
-    def tokenize_data(self, example):
+    def tokenize_data(self, example: Dict) -> BatchEncoding:
         """Tokenizes a single example."""
         return self.tokenizer(
             text=example["sentence"],

--- a/data.py
+++ b/data.py
@@ -45,19 +45,19 @@ class ColaDataModule(pl.LightningDataModule):
         if stage == "fit" or stage is None:
             self.data_train = self.dset["train"].map(self.tokenize_data, batched=True)
             self.data_train.set_format(
-                type="torch", columns=["input_ids", "attention_mask", "label"]
+                type="torch", columns=["input_ids", "attention_mask", "label", "sentence"]
             )
             self.data_val = self.dset["validation"].map(
                 self.tokenize_data, batched=True
             )
             self.data_val.set_format(
-                type="torch", columns=["input_ids", "attention_mask", "label"]
+                type="torch", columns=["input_ids", "attention_mask", "label", "sentence"]
             )
 
         if stage == "test":
             self.data_test = self.dset["test"].map(self.tokenize_data, batched=True)
             self.data_test.set_format(
-                type="torch", columns=["input_ids", "attention_mask", "label"]
+                type="torch", columns=["input_ids", "attention_mask", "label", "sentence"]
             )
 
         if stage == "predict":
@@ -65,7 +65,7 @@ class ColaDataModule(pl.LightningDataModule):
                 self.tokenize_data, batched=True
             )
             self.data_predict.set_format(
-                type="torch", columns=["input_ids", "attention_mask", "label"]
+                type="torch", columns=["input_ids", "attention_mask", "label", "sentence"]
             )
 
     def train_dataloader(self) -> DataLoader:

--- a/data.py
+++ b/data.py
@@ -45,19 +45,22 @@ class ColaDataModule(pl.LightningDataModule):
         if stage == "fit" or stage is None:
             self.data_train = self.dset["train"].map(self.tokenize_data, batched=True)
             self.data_train.set_format(
-                type="torch", columns=["input_ids", "attention_mask", "label", "sentence"]
+                type="torch",
+                columns=["input_ids", "attention_mask", "label", "sentence"],
             )
             self.data_val = self.dset["validation"].map(
                 self.tokenize_data, batched=True
             )
             self.data_val.set_format(
-                type="torch", columns=["input_ids", "attention_mask", "label", "sentence"]
+                type="torch",
+                columns=["input_ids", "attention_mask", "label", "sentence"],
             )
 
         if stage == "test":
             self.data_test = self.dset["test"].map(self.tokenize_data, batched=True)
             self.data_test.set_format(
-                type="torch", columns=["input_ids", "attention_mask", "label", "sentence"]
+                type="torch",
+                columns=["input_ids", "attention_mask", "label", "sentence"],
             )
 
         if stage == "predict":
@@ -65,7 +68,8 @@ class ColaDataModule(pl.LightningDataModule):
                 self.tokenize_data, batched=True
             )
             self.data_predict.set_format(
-                type="torch", columns=["input_ids", "attention_mask", "label", "sentence"]
+                type="torch",
+                columns=["input_ids", "attention_mask", "label", "sentence"],
             )
 
     def train_dataloader(self) -> DataLoader:

--- a/model.py
+++ b/model.py
@@ -1,14 +1,18 @@
+from typing import List, Tuple, Dict, Optional
+
 import torch.nn as nn
 from torch.nn import functional as F
 from torch.optim import Optimizer
 from pytorch_lightning import LightningModule
+import torch
 import torchmetrics
+import wandb
 
 from plots import plot_confusion_matrix
 
 
 class ColaModule(LightningModule):
-    def __init__(self, model: nn.Module, head: nn.Module, optimizer: Optimizer):
+    def __init__(self, model: nn.Module, head: nn.Module, optimizer: Optimizer) -> None:
         """
         Args:
             model: PyTorch model for feature extraction
@@ -27,7 +31,7 @@ class ColaModule(LightningModule):
         self.train_accuracy = torchmetrics.Accuracy(num_classes=ncl, task=tsk)
         self.val_accuracy = torchmetrics.Accuracy(num_classes=ncl, task=tsk)
         self.test_accuracy = torchmetrics.Accuracy(num_classes=ncl, task=tsk)
-        self.val_f1 = torchmetrics.F1(num_classes=ncl, task=tsk)
+        self.val_f1 = torchmetrics.F1Score(num_classes=ncl, task=tsk)
         self.val_recall_macro = torchmetrics.Recall(num_classes=ncl, task=tsk)
         self.val_recall_micro = torchmetrics.Recall(
             num_classes=ncl, task=tsk, average="micro"
@@ -37,21 +41,16 @@ class ColaModule(LightningModule):
             num_classes=ncl, task=tsk, average="micro"
         )
 
-        self.save_hyperparameters(ignore=["model"])
+        self.save_hyperparameters(ignore=["model", "head"])
 
-    def forward(self, input_ids, attention_mask):
-        outputs = self.model(input_ids=input_ids, attention_mask=attention_mask)
-        # This accesses embeddieng of the CLS token output from the last layer
-        h_cls = outputs.last_hidden_state[:, 0, :]
-        # We pass it through the classification head to get the logits
-        logits = self.head(h_cls)
-        preds = logits.argmax(dim=-1)
-        return logits, preds
+    def training_step(self, batch: Dict, batch_idx: int) -> torch.Tensor:
+        # Forward pass
+        loss, logits, preds = self._shared_eval_step(batch)
 
-    def training_step(self, batch, batch_idx):
-        logits, preds = self.forward(batch["input_ids"], batch["attention_mask"])
-        loss = F.cross_entropy(logits, batch["label"])
+        # Update metrics
         self.train_accuracy(preds, batch["label"])
+
+        # Log metrics
         self.log("train/loss", loss, prog_bar=True, on_step=True, on_epoch=True)
         self.log(
             "train/acc",
@@ -62,10 +61,11 @@ class ColaModule(LightningModule):
         )
         return loss
 
-    def validation_step(self, batch, batch_idx):
-        self._shared_eval_step(batch, mode="val")
-        loss, logits, preds = self._shared_eval_step(batch, mode="val")
+    def validation_step(self, batch: Dict, batch_idx: int) -> Dict[str, torch.Tensor]:
+        # Forward pass
+        loss, logits, preds = self._shared_eval_step(batch)
 
+        # Update metrics
         self.val_accuracy(preds, batch["label"])
         self.val_f1(preds, batch["label"])
         self.val_recall_macro(preds, batch["label"])
@@ -73,6 +73,8 @@ class ColaModule(LightningModule):
         self.val_precision_macro(preds, batch["label"])
         self.val_precision_micro(preds, batch["label"])
 
+        # Log metrics
+        self.log("val/loss", loss, prog_bar=True, on_step=False, on_epoch=True)
         self.log(
             "val/acc", self.val_accuracy, prog_bar=True, on_step=False, on_epoch=True
         )
@@ -105,25 +107,52 @@ class ColaModule(LightningModule):
             on_step=False,
             on_epoch=True,
         )
+        return {"logits": logits, "preds": preds, "labels": batch["label"]}
 
-    def test_step(self, batch, batch_idx):
-        self._shared_eval_step(batch, mode="val")
-        loss, logits, preds = self._shared_eval_step(batch, mode="val")
+    def validation_epoch_end(self, outputs: List[Dict]) -> None:
+        labels = torch.cat([batch["labels"] for batch in outputs])
+        preds = torch.cat([batch["preds"] for batch in outputs])
+        # Log confusion matrix
+        plot = plot_confusion_matrix(
+            actual=labels.cpu().numpy(),
+            predictions=preds.cpu().numpy(),
+            figsize=(5, 5),
+        )
+        self.logger.experiment.log({"Confusion Matrix": wandb.Image(plot)})
+
+    def test_step(self, batch: Dict, batch_idx: int) -> None:
+        self._shared_eval_step(batch)
+        loss, logits, preds = self._shared_eval_step(batch)
         self.test_accuracy(preds, batch["label"])
+        self.log("test/loss", loss, prog_bar=True, on_step=False, on_epoch=True)
         self.log(
             "test/acc", self.test_accuracy, prog_bar=True, on_step=False, on_epoch=True
         )
 
-    def _shared_eval_step(self, batch, mode):
-        logits, preds = self.forward(batch["input_ids"], batch["attention_mask"])
-        loss = F.cross_entropy(logits, batch["label"])
-        self.log(f"{mode}/loss", loss, prog_bar=True, on_step=False, on_epoch=True)
-        return loss, logits, preds
-
-    def predict_step(self, batch, batch_idx, dataloader_idx=None):
+    def predict_step(
+        self, batch: Dict, batch_idx: int, dataloader_idx: Optional[int] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         logits, preds = self.forward(batch["input_ids"], batch["attention_mask"])
         probas = F.softmax(logits, dim=-1)
         return probas, preds
 
-    def configure_optimizers(self):
+    def _shared_eval_step(
+        self, batch
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Performs forward pass and returns loss, logits and predictions."""
+        logits, preds = self.forward(batch["input_ids"], batch["attention_mask"])
+        loss = F.cross_entropy(logits, batch["label"])
+        return loss, logits, preds
+
+    def forward(self, input_ids, attention_mask) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Performs forward pass and returns logits and predictions."""
+        outputs = self.model(input_ids=input_ids, attention_mask=attention_mask)
+        # This accesses embedding of the CLS token (index 0) output from the last layer
+        h_cls = outputs.last_hidden_state[:, 0, :]
+        # We pass it through the classification head to get the logits
+        logits = self.head(h_cls)
+        preds = logits.argmax(dim=-1)
+        return logits, preds
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
         return self.optimizer

--- a/model.py
+++ b/model.py
@@ -4,6 +4,8 @@ from torch.optim import Optimizer
 from pytorch_lightning import LightningModule
 import torchmetrics
 
+from plots import plot_confusion_matrix
+
 
 class ColaModule(LightningModule):
     def __init__(self, model: nn.Module, head: nn.Module, optimizer: Optimizer):

--- a/model.py
+++ b/model.py
@@ -2,7 +2,7 @@ import torch.nn as nn
 from torch.nn import functional as F
 from torch.optim import Optimizer
 from pytorch_lightning import LightningModule
-from torchmetrics.functional import accuracy
+import torchmetrics
 
 
 class ColaModule(LightningModule):
@@ -18,6 +18,23 @@ class ColaModule(LightningModule):
         self.head = head
         self.optimizer = optimizer
 
+        self.n_classes = 2
+        self.task = "binary"
+
+        ncl, tsk = self.n_classes, self.task
+        self.train_accuracy = torchmetrics.Accuracy(num_classes=ncl, task=tsk)
+        self.val_accuracy = torchmetrics.Accuracy(num_classes=ncl, task=tsk)
+        self.test_accuracy = torchmetrics.Accuracy(num_classes=ncl, task=tsk)
+        self.val_f1 = torchmetrics.F1(num_classes=ncl, task=tsk)
+        self.val_recall_macro = torchmetrics.Recall(num_classes=ncl, task=tsk)
+        self.val_recall_micro = torchmetrics.Recall(
+            num_classes=ncl, task=tsk, average="micro"
+        )
+        self.val_precision_macro = torchmetrics.Precision(num_classes=ncl, task=tsk)
+        self.val_precision_micro = torchmetrics.Precision(
+            num_classes=ncl, task=tsk, average="micro"
+        )
+
         self.save_hyperparameters(ignore=["model"])
 
     def forward(self, input_ids, attention_mask):
@@ -32,25 +49,74 @@ class ColaModule(LightningModule):
     def training_step(self, batch, batch_idx):
         logits, preds = self.forward(batch["input_ids"], batch["attention_mask"])
         loss = F.cross_entropy(logits, batch["label"])
-        train_acc = accuracy(preds, batch["label"], task="binary")
-
+        self.train_accuracy(preds, batch["label"])
         self.log("train/loss", loss, prog_bar=True, on_step=True, on_epoch=True)
-        self.log("train/acc", train_acc, prog_bar=True, on_step=False, on_epoch=True)
+        self.log(
+            "train/acc",
+            self.train_accuracy,
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+        )
         return loss
 
     def validation_step(self, batch, batch_idx):
         self._shared_eval_step(batch, mode="val")
+        loss, logits, preds = self._shared_eval_step(batch, mode="val")
+
+        self.val_accuracy(preds, batch["label"])
+        self.val_f1(preds, batch["label"])
+        self.val_recall_macro(preds, batch["label"])
+        self.val_recall_micro(preds, batch["label"])
+        self.val_precision_macro(preds, batch["label"])
+        self.val_precision_micro(preds, batch["label"])
+
+        self.log(
+            "val/acc", self.val_accuracy, prog_bar=True, on_step=False, on_epoch=True
+        )
+        self.log("val/f1", self.val_f1, prog_bar=True, on_step=False, on_epoch=True)
+        self.log(
+            "val/recall_macro",
+            self.val_recall_micro,
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+        )
+        self.log(
+            "val/recall_micro",
+            self.val_recall_micro,
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+        )
+        self.log(
+            "val/precision_macro",
+            self.val_precision_macro,
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+        )
+        self.log(
+            "val/precision_micro",
+            self.val_precision_micro,
+            prog_bar=True,
+            on_step=False,
+            on_epoch=True,
+        )
 
     def test_step(self, batch, batch_idx):
-        self._shared_eval_step(batch, mode="test")
+        self._shared_eval_step(batch, mode="val")
+        loss, logits, preds = self._shared_eval_step(batch, mode="val")
+        self.test_accuracy(preds, batch["label"])
+        self.log(
+            "test/acc", self.test_accuracy, prog_bar=True, on_step=False, on_epoch=True
+        )
 
     def _shared_eval_step(self, batch, mode):
         logits, preds = self.forward(batch["input_ids"], batch["attention_mask"])
         loss = F.cross_entropy(logits, batch["label"])
-        acc = accuracy(preds, batch["label"], task="binary")
         self.log(f"{mode}/loss", loss, prog_bar=True, on_step=False, on_epoch=True)
-        self.log(f"{mode}/acc", acc, prog_bar=True, on_step=False, on_epoch=True)
-        return loss, acc
+        return loss, logits, preds
 
     def predict_step(self, batch, batch_idx, dataloader_idx=None):
         logits, preds = self.forward(batch["input_ids"], batch["attention_mask"])

--- a/plots.py
+++ b/plots.py
@@ -1,14 +1,17 @@
+from numpy.typing import NDArray
 from matplotlib import pyplot as plt
 import seaborn as sns
 from sklearn.metrics import confusion_matrix
 
 
-def plot_confusion_matrix(actual, predictions, size=(10, 10)):
+def plot_confusion_matrix(
+    actual: NDArray, predictions: NDArray, **kwargs
+) -> plt.Figure:
     """
     Plot a confusion matrix using seaborn heatmap.
     """
     cm = confusion_matrix(actual, predictions)
-    fig = plt.figure(size=size)
+    fig = plt.figure(**kwargs)
     ax = fig.add_subplot(111)
     sns.heatmap(cm, annot=True, fmt="d", cmap="Blues", ax=ax)
     ax.set_title("Confusion Matrix")

--- a/plots.py
+++ b/plots.py
@@ -1,0 +1,17 @@
+from matplotlib import pyplot as plt
+import seaborn as sns
+from sklearn.metrics import confusion_matrix
+
+
+def plot_confusion_matrix(actual, predictions, size=(10, 10)):
+    """
+    Plot a confusion matrix using seaborn heatmap.
+    """
+    cm = confusion_matrix(actual, predictions)
+    fig = plt.figure(size=size)
+    ax = fig.add_subplot(111)
+    sns.heatmap(cm, annot=True, fmt="d", cmap="Blues", ax=ax)
+    ax.set_title("Confusion Matrix")
+    ax.set_ylabel("Actual")
+    ax.set_xlabel("Predicted")
+    return fig

--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 import os
 
 import torch
+import wandb
 from transformers import AutoTokenizer, AutoModel
 from data import ColaDataModule
 from torch.optim import Adam
@@ -67,6 +68,7 @@ if __name__ == "__main__":
         max_steps=max_steps,
         fast_dev_run=fast_dev_run,
         logger=logger,
-        callbacks=callbacks,
+        callbacks=callbacks
     )
     trainer.fit(model=colamodule, datamodule=datamodule)
+    wandb.finish()

--- a/train.py
+++ b/train.py
@@ -46,8 +46,7 @@ if __name__ == "__main__":
         ]
     )
     colamodule = ColaModule(model=model, head=head, optimizer=optimizer)
-    wandb_logger = pl_loggers.WandbLogger(
-        project="mlops-tutorial", save_dir="logs")
+    wandb_logger = pl_loggers.WandbLogger(project="mlops-tutorial", save_dir="logs")
 
     ckpt_callback = pl_callbacks.ModelCheckpoint(
         dirpath="models",

--- a/train.py
+++ b/train.py
@@ -43,7 +43,8 @@ if __name__ == "__main__":
         ]
     )
     colamodule = ColaModule(model=model, head=head, optimizer=optimizer)
-    logger = pl_loggers.TensorBoardLogger("logs", name="cola")
+    wandb_logger = pl_loggers.WandbLogger(project="mlops-tutorial")
+    mlflow_logger = pl_loggers.MLFlowLogger(experiment_name="mlops-tutorial")
     ckpt_callback = pl_callbacks.ModelCheckpoint(
         dirpath="models",
         monitor="val/loss",
@@ -51,12 +52,16 @@ if __name__ == "__main__":
         mode="min",
         save_last=True,
     )
+
+    logger = [wandb_logger, mlflow_logger]
+    callbacks = [ckpt_callback]
+
     trainer = Trainer(
         gpus=(1 if torch.cuda.is_available() else 0),
         max_epochs=max_epochs,
         max_steps=max_steps,
         fast_dev_run=fast_dev_run,
         logger=logger,
-        callbacks=[ckpt_callback],
+        callbacks=callbacks,
     )
     trainer.fit(model=colamodule, datamodule=datamodule)

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ from pytorch_lightning import Trainer
 from pytorch_lightning import loggers as pl_loggers
 from pytorch_lightning import callbacks as pl_callbacks
 
+from callbacks import SamplesVisualisationLogger
 
 if __name__ == "__main__":
     # Config
@@ -46,7 +47,7 @@ if __name__ == "__main__":
     )
     colamodule = ColaModule(model=model, head=head, optimizer=optimizer)
     wandb_logger = pl_loggers.WandbLogger(
-        project="mlops-tutorial", save_dir=os.path.join(os.getcwd(), "logs"))
+        project="mlops-tutorial", save_dir="logs")
 
     ckpt_callback = pl_callbacks.ModelCheckpoint(
         dirpath="models",
@@ -56,8 +57,9 @@ if __name__ == "__main__":
         save_last=True,
     )
 
+    samples_callback = SamplesVisualisationLogger(data_module=datamodule)
     logger = wandb_logger
-    callbacks = [ckpt_callback]
+    callbacks = [ckpt_callback, samples_callback]
 
     trainer = Trainer(
         accelerator="cpu" if torch.cuda.device_count() == 0 else "gpu",


### PR DESCRIPTION
Closes #9 
Closes #11 

Changelog
* wandb integration
* log many train/validation metrics (accuracy, recall, f1-score)
* implement confusion matrix plot and store it at end of validation epoch
* Use type hints throughout
* SamplesVisualisationLogger to log wrong predictions in the validation set
* Include sentence information in batches